### PR TITLE
Deprecated fix

### DIFF
--- a/lib/SQLBuilder.php
+++ b/lib/SQLBuilder.php
@@ -19,9 +19,9 @@ class SQLBuilder
 	private $order;
 	private $limit;
 	private $offset;
-	private $group;
-	private $having;
-	private $update;
+	private $group = '';
+	private $having = '';
+	private $update = '';
 
 	// for where
 	private $where;


### PR DESCRIPTION
Properties update/group/having don't have default values and can cause troubles in 8.1 (for example I encountered null passed to strlen function in SQLbuilder.php, which is deprecated in php 8.1).